### PR TITLE
chore: bumps topsort sdk version

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -26,7 +26,7 @@
     "slugify": "^1.6.4",
     "unescape": "^1.0.1",
     "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.54.0-beta.1/public",
-    "@topsort/sdk": "^0.2.1"
+    "@topsort/sdk": "^0.3.1"
   },
   "devDependencies": {
     "@types/atob": "^2.1.2",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -505,10 +505,10 @@
   dependencies:
     type-detect "4.0.8"
 
-"@topsort/sdk@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@topsort/sdk/-/sdk-0.2.1.tgz#d6a8a4b8238c363db92a87062c033f6220b4769a"
-  integrity sha512-npAYCHUgoLuG8YBA4MsMhEULl3IgGgqpIOpC2Hk7xLQ0muFkKiGwpkWIOxIx2DIcKwyg4EiB0aDs5ZWzixm8Sw==
+"@topsort/sdk@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@topsort/sdk/-/sdk-0.3.1.tgz#41f70ebc691ea8e4003937be6444b3ed705eaad7"
+  integrity sha512-rXL2QlNtX+W6cwR/GGTsLCGpPyBWAltYaStMVMrTCVKnr90HmWc7bhDv6rZjf0A0OwCDLC2jNkagBDvk9N0hoQ==
 
 "@types/accepts@*":
   version "1.3.7"


### PR DESCRIPTION
This PR bumps Topsort SDK version to 0.3.1